### PR TITLE
enable debug version (#611)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ enable_testing()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake")
 find_package(MKL REQUIRED)
 
+# debug option
+set(DEBUG "off" CACHE STRING "set debug version")
+message(STATUS "debug is set to " ${DEBUG})
+if (${DEBUG} STREQUAL "on")
+    add_compile_options(-debug=minimal -Rno-debug-disables-optimization)
+endif ()
+
 add_compile_options(-fsycl)
 add_link_options(-fsycl -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -lm)
 link_libraries(-lgtest -lgtest_main)


### PR DESCRIPTION
use "cmake .. -DDEBUG=on" to build debug version, default is off.